### PR TITLE
64 Fail if cargo fails 

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,6 +17,8 @@ pub enum FztError {
     PythonParser(String),
     RustParser(syn::Error),
     InvalidArgument(String),
+    RustError(String),
+    PythonError(String),
 }
 
 impl std::error::Error for FztError {}
@@ -37,6 +39,8 @@ impl Display for FztError {
             FztError::PythonParser(error) => write!(f, "{}", error),
             FztError::RustParser(syn_error) => write!(f, "{}", syn_error),
             FztError::InvalidArgument(error) => write!(f, "{}", error),
+            FztError::RustError(error) => write!(f, "{}", error),
+            FztError::PythonError(error) => write!(f, "{}", error),
         }
     }
 }

--- a/src/tests/python/pytest/tests.rs
+++ b/src/tests/python/pytest/tests.rs
@@ -24,6 +24,14 @@ fn get_pytests() -> Result<String, FztError> {
         .arg("-q")
         .output()
         .expect("failed to retrieve python tests");
+    if binding.status.success() == false {
+        let err = std::str::from_utf8(binding.stderr.as_slice())
+            .map(|out| out.to_string())
+            .map_err(FztError::from)?;
+        return Err(FztError::PythonError(format!(
+            "Failed to run `python -m pytest --co -q`\n{err}"
+        )));
+    }
     str::from_utf8(binding.stdout.as_slice())
         .map(|out| out.to_string())
         .map_err(FztError::from)

--- a/src/tests/rust/rust_test_parser.rs
+++ b/src/tests/rust/rust_test_parser.rs
@@ -20,6 +20,14 @@ impl ParseRustTest for RustTestParser {
         let output = std::str::from_utf8(binding.stdout.as_slice())
             .map(|out| out.to_string())
             .map_err(FztError::from)?;
+        if binding.status.success() == false {
+            let err = std::str::from_utf8(binding.stderr.as_slice())
+                .map(|out| out.to_string())
+                .map_err(FztError::from)?;
+            return Err(FztError::RustError(format!(
+                "Failed to run `cargo test -- --list`\n{err}"
+            )));
+        }
         let mut tests = Vec::new();
         for line in output.lines() {
             if line.is_empty() {


### PR DESCRIPTION
This pull request improves error handling for both Python and Rust test discovery by introducing new error variants and ensuring that failures in subprocess execution are reported clearly. The main changes include adding `RustError` and `PythonError` variants to the `FztError` enum, updating error formatting, and handling subprocess failures in test discovery functions.

### Error handling improvements

* Added `RustError` and `PythonError` variants to the `FztError` enum in `src/errors.rs` to allow for more specific error reporting.
* Updated the `Display` implementation for `FztError` to properly format and display the new error variants.
