### PR TITLE
68 increase lines of tests preview

### DIFF
--- a/src/cli/default.rs
+++ b/src/cli/default.rs
@@ -13,7 +13,7 @@ pub fn get_default(project_id: &str, config: RunnerConfig) -> Result<Box<dyn Run
         Some(reader) => serde_json::from_reader(reader)?,
         None => {
             return Err(FztError::GeneralParsingError(
-                "Metadata not found. Did you initialized the project `fzt -d <LANGUAGE>` ?"
+                "Metadata not found. Did you initialize the project `fzt -d <LANGUAGE>` ?"
                     .to_string(),
             ));
         }

--- a/src/search_engine/fzf/bat_preview_command.sh
+++ b/src/search_engine/fzf/bat_preview_command.sh
@@ -25,6 +25,6 @@ for line_num in $line_numbers; do
         echo
     fi
 
-    less "$file" | bat -r "$line_num:+$context" --style=numbers --color=always --language="$language"
+    bat -r "$line_num:+$context" --style=numbers --color=always --language="$language" "$file"
 
 done

--- a/src/search_engine/fzf/mod.rs
+++ b/src/search_engine/fzf/mod.rs
@@ -9,7 +9,7 @@ use super::Append;
 use super::SearchEngine;
 
 const BAT_PREVIEW_SCRIPT: &str = include_str!("bat_preview_command.sh");
-const BAT_LINE_PREVIEW_CONTEXT: &i8 = &20;
+const BAT_LINE_PREVIEW_CONTEXT: i8 = 20;
 
 fn run_fzf(
     input: &str,


### PR DESCRIPTION
This pull request introduces improvements to the search preview functionality and error messaging in the CLI, primarily focusing on enhancing the user experience when searching and previewing code. The most important changes are grouped below by theme.

**Search Preview Enhancements:**

* Added a new Bash script `bat_preview_command.sh` that previews search results with syntax highlighting and context lines, improving readability and navigation of search matches.
* Integrated the new preview script into the FZF search engine by including its contents in the Rust code (`BAT_PREVIEW_SCRIPT`) and using it for previewing search results. The preview now displays up to 20 lines of context around each match. 

**CLI Error Messaging:**

* Improved the error message when project metadata is missing to suggest initializing the project with the appropriate command, making troubleshooting easier for users.