### PR TITLE
101 Capture stderr

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,6 +21,7 @@ pub enum FztError {
     RustError(String),
     PythonError(String),
     InternalError(String),
+    RuntumeError(String),
 }
 
 impl std::error::Error for FztError {}
@@ -45,6 +46,7 @@ impl Display for FztError {
             FztError::PythonError(error) => write!(f, "{}", error),
             FztError::StringFromUtf8(error) => write!(f, "{}", error),
             FztError::InternalError(error) => write!(f, "{}", error),
+            FztError::RuntumeError(error) => write!(f, "{}", error),
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,7 +21,7 @@ pub enum FztError {
     RustError(String),
     PythonError(String),
     InternalError(String),
-    RuntumeError(String),
+    RuntimeError(String),
 }
 
 impl std::error::Error for FztError {}
@@ -46,7 +46,7 @@ impl Display for FztError {
             FztError::PythonError(error) => write!(f, "{}", error),
             FztError::StringFromUtf8(error) => write!(f, "{}", error),
             FztError::InternalError(error) => write!(f, "{}", error),
-            FztError::RuntumeError(error) => write!(f, "{}", error),
+            FztError::RuntimeError(error) => write!(f, "{}", error),
         }
     }
 }

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -25,6 +25,19 @@ pub fn run_and_capture_print<F: RuntimeFormatter>(
         }
     }
 
+    if let Some(stderr) = child.stderr.take() {
+        let reader = BufReader::new(stderr);
+        let mut error_output = String::new();
+        for line in reader.lines() {
+            let line = line?;
+            error_output.push_str(&line);
+            error_output.push('\n');
+        }
+        if !error_output.is_empty() {
+            return Err(FztError::RuntumeError(error_output));
+        }
+    }
+
     child.wait()?;
     let plain_bytes = strip_ansi_escapes::strip(output.as_bytes());
     String::from_utf8(plain_bytes).map_err(|e| FztError::from(e))

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -34,7 +34,7 @@ pub fn run_and_capture_print<F: RuntimeFormatter>(
             error_output.push('\n');
         }
         if !error_output.is_empty() {
-            return Err(FztError::RuntumeError(error_output));
+            return Err(FztError::RuntimeError(error_output));
         }
     }
 


### PR DESCRIPTION
This pull request introduces improved error handling for runtime errors and updates the error reporting logic in the `run_and_capture_print` function. The main changes involve adding a new error variant to the `FztError` enum and capturing standard error output from child processes.
