### PR TITLE
105 Library structure

### DIFF
--- a/src/cache/manager.rs
+++ b/src/cache/manager.rs
@@ -22,7 +22,7 @@ pub enum HistoryGranularity {
 }
 
 #[derive(Clone)]
-pub struct CacheManager {
+pub struct LocalCacheManager {
     cache_file: PathBuf,
     history_test_granularity: PathBuf,
     history_file_granularity: PathBuf,
@@ -31,7 +31,7 @@ pub struct CacheManager {
     history_continues_append_granularity: PathBuf,
 }
 
-impl CacheManager {
+impl LocalCacheManager {
     pub fn new_failed_tests(project_id: &str) -> Self {
         let mut cache_location = home_dir().expect("Could not find home directory");
         cache_location.push(".fzt");
@@ -121,7 +121,7 @@ impl CacheManager {
     }
 }
 
-impl Cache for CacheManager {
+impl Cache for LocalCacheManager {
     fn get_entry(&self) -> Result<Option<BufReader<File>>, FztError> {
         if !Path::new(&self.cache_file).exists() {
             Ok(None)
@@ -234,7 +234,7 @@ mod tests {
     #[test]
     fn get_non_existing_entry() {
         let path = PathBuf::from("/ifhoeowhfoew/oihsoehwofihwoih.json");
-        let manager = CacheManager::new_from_path(
+        let manager = LocalCacheManager::new_from_path(
             path,
             PathBuf::from("file.path()"),
             PathBuf::from(""),
@@ -250,7 +250,7 @@ mod tests {
     fn get_existing_entry() {
         let file = NamedTempFile::new().unwrap();
         let path = PathBuf::from(file.path());
-        let manager = CacheManager::new_from_path(
+        let manager = LocalCacheManager::new_from_path(
             path,
             PathBuf::from("file.path()"),
             PathBuf::from(""),
@@ -269,7 +269,7 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         writeln!(file, "Old").unwrap();
         let path = PathBuf::from(file.path());
-        let manager = CacheManager::new_from_path(
+        let manager = LocalCacheManager::new_from_path(
             path.clone(),
             PathBuf::from("file.path()"),
             PathBuf::from(""),

--- a/src/cache/manager.rs
+++ b/src/cache/manager.rs
@@ -8,6 +8,8 @@ use std::{
 
 use crate::errors::FztError;
 
+use super::Cache;
+
 const HISTORY_SIZE: usize = 200;
 
 #[derive(Clone, PartialEq)]
@@ -30,17 +32,17 @@ pub struct CacheManager {
 }
 
 impl CacheManager {
-    pub fn new_failed_tests(project_id: String) -> Self {
+    pub fn new_failed_tests(project_id: &str) -> Self {
         let mut cache_location = home_dir().expect("Could not find home directory");
         cache_location.push(".fzt");
 
-        let mut cache_manager = Self::new(format!("{}-failed", project_id));
+        let mut cache_manager = Self::new(format!("{}-failed", project_id).as_str());
         // The test cache file still stays the same
         cache_manager.cache_file = cache_location.join(format!("{}.json", project_id));
         cache_manager
     }
 
-    pub fn new(project_id: String) -> Self {
+    pub fn new(project_id: &str) -> Self {
         let mut cache_location = home_dir().expect("Could not find home directory");
         cache_location.push(".fzt");
         let cache_file = cache_location.join(format!("{}.json", project_id));
@@ -56,6 +58,24 @@ impl CacheManager {
             "{}-history-continues-append-granularity.json",
             project_id
         ));
+        Self {
+            cache_file,
+            history_test_granularity,
+            history_file_granularity,
+            history_directory_granularity,
+            history_runtime_granularity,
+            history_continues_append_granularity,
+        }
+    }
+
+    pub fn new_from_path(
+        cache_file: PathBuf,
+        history_test_granularity: PathBuf,
+        history_file_granularity: PathBuf,
+        history_directory_granularity: PathBuf,
+        history_runtime_granularity: PathBuf,
+        history_continues_append_granularity: PathBuf,
+    ) -> Self {
         Self {
             cache_file,
             history_test_granularity,
@@ -90,25 +110,19 @@ impl CacheManager {
         }
     }
 
-    pub fn new_from_path(
-        cache_file: PathBuf,
-        history_test_granularity: PathBuf,
-        history_file_granularity: PathBuf,
-        history_directory_granularity: PathBuf,
-        history_runtime_granularity: PathBuf,
-        history_continues_append_granularity: PathBuf,
-    ) -> Self {
-        Self {
-            cache_file,
-            history_test_granularity,
-            history_file_granularity,
-            history_directory_granularity,
-            history_runtime_granularity,
-            history_continues_append_granularity,
+    fn get_history_file(&self, granularity: &HistoryGranularity) -> &PathBuf {
+        match granularity {
+            HistoryGranularity::Test => &self.history_test_granularity,
+            HistoryGranularity::File => &self.history_file_granularity,
+            HistoryGranularity::Directory => &self.history_directory_granularity,
+            HistoryGranularity::RunTime => &self.history_runtime_granularity,
+            HistoryGranularity::Append => &self.history_continues_append_granularity,
         }
     }
+}
 
-    pub fn get_entry(&self) -> Result<Option<BufReader<File>>, FztError> {
+impl Cache for CacheManager {
+    fn get_entry(&self) -> Result<Option<BufReader<File>>, FztError> {
         if !Path::new(&self.cache_file).exists() {
             Ok(None)
         } else {
@@ -117,21 +131,21 @@ impl CacheManager {
         }
     }
 
-    pub fn add_entry(&self, entry: &str) -> Result<(), FztError> {
+    fn add_entry(&self, entry: &str) -> Result<(), FztError> {
         let file = File::create(&self.cache_file)?;
         let mut writer = BufWriter::new(file);
         writer.write(entry.as_bytes())?;
         Ok(())
     }
 
-    pub fn clear_cache(&self) -> Result<(), FztError> {
+    fn clear_cache(&self) -> Result<(), FztError> {
         if Path::new(&self.cache_file).exists() {
             std::fs::remove_file(&self.cache_file)?;
         }
         Ok(())
     }
 
-    pub fn clear_history(&self) -> Result<(), FztError> {
+    fn clear_history(&self) -> Result<(), FztError> {
         if Path::new(&self.history_test_granularity).exists() {
             std::fs::remove_file(&self.history_test_granularity)?;
         }
@@ -150,17 +164,7 @@ impl CacheManager {
         Ok(())
     }
 
-    fn get_history_file(&self, granularity: &HistoryGranularity) -> &PathBuf {
-        match granularity {
-            HistoryGranularity::Test => &self.history_test_granularity,
-            HistoryGranularity::File => &self.history_file_granularity,
-            HistoryGranularity::Directory => &self.history_directory_granularity,
-            HistoryGranularity::RunTime => &self.history_runtime_granularity,
-            HistoryGranularity::Append => &self.history_continues_append_granularity,
-        }
-    }
-
-    pub fn update_history(
+    fn update_history(
         &self,
         selection: &[String],
         granularity: &HistoryGranularity,
@@ -189,7 +193,7 @@ impl CacheManager {
         Ok(())
     }
 
-    pub fn recent_history_command(
+    fn recent_history_command(
         &self,
         granularity: &HistoryGranularity,
     ) -> Result<Vec<String>, FztError> {
@@ -205,7 +209,7 @@ impl CacheManager {
         }
     }
 
-    pub fn history(&self, granularity: &HistoryGranularity) -> Result<Vec<Vec<String>>, FztError> {
+    fn history(&self, granularity: &HistoryGranularity) -> Result<Vec<Vec<String>>, FztError> {
         let history_file = self.get_history_file(granularity);
 
         if !Path::new(history_file).exists() {

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,3 +1,26 @@
+use std::{fs::File, io::BufReader};
+
+use manager::HistoryGranularity;
+
+use crate::errors::FztError;
+
 pub mod helper;
 pub mod manager;
 pub mod types;
+
+pub trait Cache {
+    fn get_entry(&self) -> Result<Option<BufReader<File>>, FztError>;
+    fn add_entry(&self, entry: &str) -> Result<(), FztError>;
+    fn clear_cache(&self) -> Result<(), FztError>;
+    fn clear_history(&self) -> Result<(), FztError>;
+    fn update_history(
+        &self,
+        selection: &[String],
+        granularity: &HistoryGranularity,
+    ) -> Result<(), FztError>;
+    fn recent_history_command(
+        &self,
+        granularity: &HistoryGranularity,
+    ) -> Result<Vec<String>, FztError>;
+    fn history(&self, granularity: &HistoryGranularity) -> Result<Vec<Vec<String>>, FztError>;
+}

--- a/src/cli/default.rs
+++ b/src/cli/default.rs
@@ -1,11 +1,11 @@
 use crate::{
-    cache::manager::CacheManager,
+    cache::manager::LocalCacheManager,
     errors::FztError,
     runner::{MetaData, RunnerName, config::Language},
 };
 
 pub fn get_default(project_id: &str) -> Result<Language, FztError> {
-    let reader = CacheManager::get_meta(project_id)?;
+    let reader = LocalCacheManager::get_meta(project_id)?;
     let meta_data: MetaData = match reader {
         Some(reader) => serde_json::from_reader(reader)?,
         None => {

--- a/src/cli/default.rs
+++ b/src/cli/default.rs
@@ -1,13 +1,10 @@
 use crate::{
     cache::manager::CacheManager,
     errors::FztError,
-    runner::{MetaData, Runner, RunnerConfig, RunnerName},
-    search_engine::fzf::FzfSearchEngine,
+    runner::{MetaData, RunnerName, config::Language},
 };
 
-use super::{java::get_java_runner, python::get_python_runner, rust::get_rust_runner};
-
-pub fn get_default(project_id: &str, config: RunnerConfig) -> Result<Box<dyn Runner>, FztError> {
+pub fn get_default(project_id: &str) -> Result<Language, FztError> {
     let reader = CacheManager::get_meta(project_id)?;
     let meta_data: MetaData = match reader {
         Some(reader) => serde_json::from_reader(reader)?,
@@ -19,29 +16,19 @@ pub fn get_default(project_id: &str, config: RunnerConfig) -> Result<Box<dyn Run
         }
     };
 
-    match meta_data.runner_name {
-        RunnerName::RustPythonRunner => get_python_runner(
-            "rustpython",
-            meta_data.runtime.as_str(),
-            config,
-            FzfSearchEngine::default(),
-        ),
-        RunnerName::PytestRunner => get_python_runner(
-            "pytest",
-            meta_data.runtime.as_str(),
-            config,
-            FzfSearchEngine::default(),
-        ),
-        RunnerName::JavaJunit5Runner => get_java_runner(
-            "junit5",
-            meta_data.runtime.as_str(),
-            config,
-            FzfSearchEngine::default(),
-        ),
-        RunnerName::RustCargoRunner => get_rust_runner(config, FzfSearchEngine::default()),
-    }
-}
-
-pub fn set_default(project_id: &str, meta_data: &str) -> Result<(), FztError> {
-    CacheManager::save_meta(project_id, meta_data)
+    Ok(match meta_data.runner_name {
+        RunnerName::RustPythonRunner => Language::Python {
+            parser: "rustpython".to_string(),
+            runtime: meta_data.runtime,
+        },
+        RunnerName::PytestRunner => Language::Python {
+            parser: "pytest".to_string(),
+            runtime: meta_data.runtime,
+        },
+        RunnerName::JavaJunit5Runner => Language::Java {
+            test_framework: "junit5".to_string(),
+            runtime: meta_data.runtime,
+        },
+        RunnerName::RustCargoRunner => Language::Rust,
+    })
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,9 @@
+use crate::{runner::config::RunnerConfig, search_engine::fzf::FzfSearchEngine};
+
 pub mod cli_parser;
 mod default;
-mod java;
-mod python;
-mod rust;
+
+pub struct Config {
+    pub runner_config: RunnerConfig<FzfSearchEngine>,
+    pub default: bool,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,52 @@
 pub mod cache;
 pub mod cli;
 pub mod errors;
-pub mod runner;
-pub mod runtime;
-pub mod search_engine;
-pub mod tests;
-pub mod utils;
+mod runner;
+mod runtime;
+mod search_engine;
+mod tests;
+mod utils;
+
+pub use cache::Cache;
+pub use cache::manager::LocalCacheManager;
+pub use errors::FztError;
+
+pub use runner::Runner;
+pub use runner::config::FilterMode;
+pub use runner::config::Language;
+pub use runner::config::Preview;
+pub use runner::config::RunnerConfig;
+pub use runner::config::RunnerMode;
+pub use runner::java::get_java_runner;
+pub use runner::python::get_python_runner;
+pub use runner::rust::get_rust_runner;
+
+pub use runtime::Debugger;
+pub use runtime::JavaDebugger;
+pub use runtime::PythonDebugger;
+pub use runtime::Runtime;
+pub use runtime::RustDebugger;
+pub use runtime::java::gradle::GradleRuntime;
+pub use runtime::python::pytest::PytestRuntime;
+pub use runtime::rust::cargo::CargoRuntime;
+
+pub use search_engine::SearchEngine;
+pub use search_engine::fzf::FzfSearchEngine;
+
+pub use tests::Test;
+pub use tests::Tests;
+pub use tests::java::java_test::JavaTestItem;
+pub use tests::java::java_test::JavaTests;
+pub use tests::java::parser::JavaParser;
+pub use tests::python::pytest::tests::PytestTests;
+pub use tests::python::python_test::PythonTest;
+pub use tests::python::rust_python::tests::RustPytonTests;
+pub use tests::rust::rust_test::RustTest;
+pub use tests::rust::rust_test::RustTestItem;
+pub use tests::rust::rust_test::RustTests;
+pub use tests::test_provider::SelectGranularity;
+pub use tests::test_provider::TestProvider;
+
+pub use utils::file_walking::collect_tests;
+pub use utils::file_walking::filter_out_deleted_files;
+pub use utils::path_resolver::get_relative_path;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use FzT::{
-    cache::{helper::project_hash, manager::CacheManager},
+    cache::{helper::project_hash, manager::LocalCacheManager},
     cli::cli_parser::parse_cli,
     errors::FztError,
 };
@@ -9,7 +9,7 @@ fn main() -> Result<(), FztError> {
     let default = config.default;
     let mut runner = config.runner_config.into_runner()?;
     if default {
-        CacheManager::save_meta(project_hash()?.as_str(), runner.meta_data()?.as_str())?;
+        LocalCacheManager::save_meta(project_hash()?.as_str(), runner.meta_data()?.as_str())?;
     }
     runner.run()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,15 @@
-use FzT::{cli::cli_parser::parse_cli, errors::FztError};
+use FzT::{
+    cache::{helper::project_hash, manager::CacheManager},
+    cli::cli_parser::parse_cli,
+    errors::FztError,
+};
 
 fn main() -> Result<(), FztError> {
-    let mut runner = parse_cli()?;
+    let config = parse_cli()?;
+    let default = config.default;
+    let mut runner = config.runner_config.into_runner()?;
+    if default {
+        CacheManager::save_meta(project_hash()?.as_str(), runner.meta_data()?.as_str())?;
+    }
     runner.run()
 }

--- a/src/runner/config.rs
+++ b/src/runner/config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    cache::{helper::project_hash, manager::CacheManager},
+    cache::{helper::project_hash, manager::LocalCacheManager},
     errors::FztError,
     runtime::Debugger,
     search_engine::SearchEngine,
@@ -93,11 +93,11 @@ impl<SE: SearchEngine> RunnerConfig<SE> {
         }
     }
 
-    fn build_cache_manager(&self, project_id: &str) -> CacheManager {
+    fn build_cache_manager(&self, project_id: &str) -> LocalCacheManager {
         if self.run_failed {
-            CacheManager::new_failed_tests(project_id)
+            LocalCacheManager::new_failed_tests(project_id)
         } else {
-            CacheManager::new(project_id)
+            LocalCacheManager::new(project_id)
         }
     }
 

--- a/src/runner/config.rs
+++ b/src/runner/config.rs
@@ -1,0 +1,103 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{errors::FztError, runtime::Debugger, search_engine::SearchEngine};
+
+use super::{Runner, java::get_java_runner, python::get_python_runner, rust::get_rust_runner};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum RunnerMode {
+    All,
+    Last,
+    History,
+    Select,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum Preview {
+    File,
+    Test,
+    Directory,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum FilterMode {
+    Test,
+    File,
+    Directory,
+    RunTime,
+    Append,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum Language {
+    Python {
+        parser: String,
+        runtime: String,
+    },
+    Java {
+        test_framework: String,
+        runtime: String,
+    },
+    Rust,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RunnerConfig<SE: SearchEngine + 'static> {
+    pub clear_cache: bool,
+    pub verbose: bool,
+    pub clear_history: bool,
+    pub runtime_args: Vec<String>,
+    pub mode: RunnerMode,
+    pub preview: Option<Preview>,
+    pub filter_mode: FilterMode,
+    pub query: Option<String>,
+    pub debugger: Option<Debugger>,
+    pub run_failed: bool,
+    pub language: Language,
+    pub search_engine: SE,
+}
+
+impl<SE: SearchEngine> RunnerConfig<SE> {
+    pub fn new(
+        clear_cache: bool,
+        verbose: bool,
+        clear_history: bool,
+        runtime_args: Vec<String>,
+        mode: RunnerMode,
+        preview: Option<Preview>,
+        filter_mode: FilterMode,
+        query: Option<String>,
+        debugger: Option<Debugger>,
+        run_failed: bool,
+        language: Language,
+        search_engine: SE,
+    ) -> Self {
+        Self {
+            clear_cache,
+            verbose,
+            clear_history,
+            runtime_args,
+            mode,
+            preview,
+            filter_mode,
+            query,
+            debugger,
+            run_failed,
+            language,
+            search_engine,
+        }
+    }
+
+    pub fn into_runner(self) -> Result<Box<dyn Runner>, FztError> {
+        match self.language.clone() {
+            Language::Python { parser, runtime } => {
+                get_python_runner(parser.as_str(), runtime.as_str(), self)
+            }
+            Language::Java {
+                test_framework,
+                runtime,
+            } => get_java_runner(test_framework.as_str(), runtime.as_str(), self),
+            Language::Rust => get_rust_runner(self),
+        }
+    }
+}

--- a/src/runner/history_provider.rs
+++ b/src/runner/history_provider.rs
@@ -1,15 +1,15 @@
 use crate::{
-    cache::manager::{CacheManager, HistoryGranularity},
+    cache::{Cache, manager::HistoryGranularity},
     errors::FztError,
     search_engine::SearchEngine,
 };
 
-pub struct HistoryProvider {
-    cache_manager: CacheManager,
+pub struct HistoryProvider<CM: Cache> {
+    cache_manager: CM,
 }
 
-impl HistoryProvider {
-    pub fn new(cache_manager: CacheManager) -> Self {
+impl<CM: Cache> HistoryProvider<CM> {
+    pub fn new(cache_manager: CM) -> Self {
         Self { cache_manager }
     }
 

--- a/src/runner/java.rs
+++ b/src/runner/java.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use crate::{
-    cache::helper::project_hash,
+    cache::Cache,
     errors::FztError,
     runner::{RunnerName, general_runner::GeneralCacheRunner},
     runtime::{Debugger, java::gradle::GradleRuntime},
@@ -11,10 +11,11 @@ use crate::{
 
 use super::{Runner, config::RunnerConfig};
 
-pub fn get_java_runner<SE: SearchEngine + 'static>(
+pub fn get_java_runner<SE: SearchEngine + 'static, CM: Cache + Clone + 'static>(
     test_framework: &str,
     runtime: &str,
     config: RunnerConfig<SE>,
+    cache_manager: CM,
 ) -> Result<Box<dyn Runner>, FztError> {
     if let Some(debugger) = config.debugger.as_ref() {
         if !matches!(debugger, Debugger::Java(_)) {
@@ -33,8 +34,8 @@ pub fn get_java_runner<SE: SearchEngine + 'static>(
             GradleRuntime::default(),
             config,
             JavaTests::new_empty(path_str.to_string()),
-            format!("{}-java-junit5", project_hash()?),
             RunnerName::JavaJunit5Runner,
+            cache_manager,
         ))),
         _ => {
             return Err(FztError::GeneralParsingError(format!(

--- a/src/runner/java.rs
+++ b/src/runner/java.rs
@@ -3,17 +3,18 @@ use std::env;
 use crate::{
     cache::helper::project_hash,
     errors::FztError,
-    runner::{Runner, RunnerConfig, RunnerName, general_runner::GeneralCacheRunner},
+    runner::{RunnerName, general_runner::GeneralCacheRunner},
     runtime::{Debugger, java::gradle::GradleRuntime},
     search_engine::SearchEngine,
     tests::java::java_test::JavaTests,
 };
 
+use super::{Runner, config::RunnerConfig};
+
 pub fn get_java_runner<SE: SearchEngine + 'static>(
     test_framework: &str,
     runtime: &str,
-    config: RunnerConfig,
-    search_engine: SE,
+    config: RunnerConfig<SE>,
 ) -> Result<Box<dyn Runner>, FztError> {
     if let Some(debugger) = config.debugger.as_ref() {
         if !matches!(debugger, Debugger::Java(_)) {
@@ -29,7 +30,6 @@ pub fn get_java_runner<SE: SearchEngine + 'static>(
         runtime.to_lowercase().as_str(),
     ) {
         ("junit5", "gradle") => Ok(Box::new(GeneralCacheRunner::new(
-            search_engine,
             GradleRuntime::default(),
             config,
             JavaTests::new_empty(path_str.to_string()),

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1,8 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{errors::FztError, runtime::Debugger};
+use crate::errors::FztError;
 
+pub mod config;
 pub mod general_runner;
+pub mod java;
+pub mod python;
+pub mod rust;
+
 mod history_provider;
 
 pub trait Runner {
@@ -23,70 +28,4 @@ pub struct MetaData {
     pub runner_name: RunnerName,
     pub search_engine: String,
     pub runtime: String,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum RunnerMode {
-    All,
-    Last,
-    History,
-    Select,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum Preview {
-    File,
-    Test,
-    Directory,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum FilterMode {
-    Test,
-    File,
-    Directory,
-    RunTime,
-    Append,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct RunnerConfig {
-    pub clear_cache: bool,
-    pub verbose: bool,
-    pub clear_history: bool,
-    pub runtime_args: Vec<String>,
-    pub mode: RunnerMode,
-    pub preview: Option<Preview>,
-    pub filter_mode: FilterMode,
-    pub query: Option<String>,
-    pub debugger: Option<Debugger>,
-    pub run_failed: bool,
-}
-
-impl RunnerConfig {
-    pub fn new(
-        clear_cache: bool,
-        verbose: bool,
-        clear_history: bool,
-        runtime_args: Vec<String>,
-        mode: RunnerMode,
-        preview: Option<Preview>,
-        filter_mode: FilterMode,
-        query: Option<String>,
-        debugger: Option<Debugger>,
-        run_failed: bool,
-    ) -> Self {
-        Self {
-            clear_cache,
-            verbose,
-            clear_history,
-            runtime_args,
-            mode,
-            preview,
-            filter_mode,
-            query,
-            debugger,
-            run_failed,
-        }
-    }
 }

--- a/src/runner/rust.rs
+++ b/src/runner/rust.rs
@@ -3,15 +3,16 @@ use std::env;
 use crate::{
     cache::helper::project_hash,
     errors::FztError,
-    runner::{Runner, RunnerConfig, RunnerName, general_runner::GeneralCacheRunner},
+    runner::{RunnerName, general_runner::GeneralCacheRunner},
     runtime::{Debugger, rust::cargo::CargoRuntime},
     search_engine::SearchEngine,
     tests::rust::rust_test::RustTests,
 };
 
+use super::{Runner, config::RunnerConfig};
+
 pub fn get_rust_runner<SE: SearchEngine + 'static>(
-    config: RunnerConfig,
-    search_engine: SE,
+    config: RunnerConfig<SE>,
 ) -> Result<Box<dyn Runner>, FztError> {
     if let Some(debugger) = config.debugger.as_ref() {
         if !matches!(debugger, Debugger::Rust(_)) {
@@ -23,7 +24,6 @@ pub fn get_rust_runner<SE: SearchEngine + 'static>(
     let path = env::current_dir()?;
     let path_str = path.to_string_lossy();
     Ok(Box::new(GeneralCacheRunner::new(
-        search_engine,
         CargoRuntime::default(),
         config,
         RustTests::new_empty(path_str.to_string()),

--- a/src/runner/rust.rs
+++ b/src/runner/rust.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use crate::{
-    cache::helper::project_hash,
+    cache::Cache,
     errors::FztError,
     runner::{RunnerName, general_runner::GeneralCacheRunner},
     runtime::{Debugger, rust::cargo::CargoRuntime},
@@ -11,8 +11,9 @@ use crate::{
 
 use super::{Runner, config::RunnerConfig};
 
-pub fn get_rust_runner<SE: SearchEngine + 'static>(
+pub fn get_rust_runner<SE: SearchEngine + 'static, CM: Cache + Clone + 'static>(
     config: RunnerConfig<SE>,
+    cache_manager: CM,
 ) -> Result<Box<dyn Runner>, FztError> {
     if let Some(debugger) = config.debugger.as_ref() {
         if !matches!(debugger, Debugger::Rust(_)) {
@@ -27,7 +28,7 @@ pub fn get_rust_runner<SE: SearchEngine + 'static>(
         CargoRuntime::default(),
         config,
         RustTests::new_empty(path_str.to_string()),
-        format!("{}-rust-cargo", project_hash()?),
         RunnerName::RustCargoRunner,
+        cache_manager,
     )))
 }

--- a/src/search_engine/fzf/mod.rs
+++ b/src/search_engine/fzf/mod.rs
@@ -3,7 +3,7 @@ use std::process::{Command, Output, Stdio};
 use std::str::{self, FromStr};
 
 use crate::errors::FztError;
-use crate::runner::Preview;
+use crate::runner::config::Preview;
 
 use super::Append;
 use super::SearchEngine;

--- a/src/search_engine/mod.rs
+++ b/src/search_engine/mod.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use crate::{errors::FztError, runner::Preview};
+use crate::{errors::FztError, runner::config::Preview};
 
 pub mod fzf;
 


### PR DESCRIPTION
Add a clear defined library structure. 

This includes moving some logic closer to their core. Like reducing the cli logic to only parsing and moving the runner creation to `runner`. 
Also making the cache logic a trait.